### PR TITLE
Error message displayed for min()/max() function

### DIFF
--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1772,7 +1772,7 @@ min_max(PyObject *args, PyObject *kwds, int op)
             maxitem = defaultval;
         } else {
             PyErr_Format(PyExc_ValueError,
-                         "%s() arg is an empty sequence", name);
+                         "%s() should have at least 1 element as an argument but, there is no argument and it is an empty sequence", name);
         }
     }
     else


### PR DESCRIPTION
#90829: **Changing the error message**  -  "ValueError: min() arg is an empty sequence"   to   "ValueError: should have at least 1 element as an argument but, there is no argument and it is an empty sequence".
- This can make the error message more comprehendible.


